### PR TITLE
fix: Change if condition to provide e2e test functionality.

### DIFF
--- a/src/lib/codemirror.component.ts
+++ b/src/lib/codemirror.component.ts
@@ -169,8 +169,9 @@ export class CodemirrorComponent
     }
   }
   codemirrorValueChanged(cm: Editor, change: EditorChangeLinkedList): void {
-    if (change.origin !== 'setValue') {
-      this.value = cm.getValue();
+    const cmVal = cm.getValue();
+    if (this.value !== cmVal) {
+      this.value = cmVal;
       this.onChange(this.value);
     }
   }


### PR DESCRIPTION
The current "hack" for testing codemirror in angular is using `browser.executeScript` with `setValue`.  Link to stackoverflow: https://stackoverflow.com/questions/30552393/how-to-write-protractor-test-for-ui-codemirror-angularjs-directive.

However, this fails for ngx-codemirror because we are ignoring some setValue calls for fewer and more accurate change-detection calls. I have tried to achieve the same by using a different if condition to facilitate end to end testing.